### PR TITLE
Add types for default export

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -37,8 +37,8 @@ export type RawTx = {
 };
 
 export function sign(privateKey: string, message: string): string;
-export function recover(sig: string, message: string);
-export function recoverPublicKey(sig: string, message: string);
+export function recover(sig: string, message: string): string;
+export function recoverPublicKey(sig: string, message: string): string;
 
 export type vrs = {
     fromString(hexString): Signature;
@@ -92,21 +92,45 @@ export type hex = {
 export function publicKeyToAddress(publicKey: string): string;
 
 declare const _default: {
-    createIdentity,
-    publicKey,
-    decryptWithPrivateKey,
-    encryptWithPublicKey,
-    cipher,
-    publicKeyByPrivateKey,
-    recover,
-    recoverPublicKey,
-    sign,
-    signTransaction,
-    txDataByCompiled,
-    calculateContractAddress,
-    hash,
-    hex,
-    vrs,
-    util
+    createIdentity: () => {
+        privateKey: string,
+        publicKey: string,
+        address: string
+    },
+    publicKey: {
+        compress(publicKey: string): string;
+        decompress(publicKey: string): string;
+        toAddress(publicKey: string): string;
+    },
+    decryptWithPrivateKey: (privateKey: string, encrypted: Encrypted) => Promise<string>,
+    encryptWithPublicKey: (publicKey: string, message: string)=> Promise<Encrypted>,
+    cipher: {
+        stringify(encrypted: Encrypted): string;
+        parse(encrypted: string): Encrypted;
+    },
+    publicKeyByPrivateKey: (privateKey: string)=> string,
+    recover: (sig: string, message: string) => string,
+    recoverPublicKey: (sig: string, message: string) => string,
+    sign: (privateKey: string, message: string) => string,
+    signTransaction: (rawTx: RawTx, privateKey: string) => string,
+    txDataByCompiled: (
+        abi: any,
+        bytecode: string,
+        args?: Array<string | number | BigNumber>
+    ) =>  string,
+    calculateContractAddress: (creatorAddress: string, nonce: number) => string,
+    hash: (params: TypedValue[]) => string,
+    hex: {
+        compress(hex: string, base64?: boolean): string;
+        decompress(str: string, base64?: boolean): string;
+    },
+    vrs: {
+        fromString(hexString): Signature;
+        toString(sig: Signature): string;
+    },
+    util: {
+        removeTrailing0x(str: string): string;
+        addTrailing0x(str: string): string;
+    }
 };
 export default _default;


### PR DESCRIPTION
Currently the project fails to compile if the Typescript `noImplicitAny` flag is enabled, because the default export in `index.d.ts` is untyped. This PR just adds those types based on the exported functions.