### PR TITLE
Upgrade Ethers package to 4.0.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "eth-lib": "0.2.8",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.1.0",
-    "ethers": "3.0.27",
+    "ethers": "4.0.32",
     "secp256k1": "3.7.1"
   }
 }

--- a/src/tx-data-by-compiled.js
+++ b/src/tx-data-by-compiled.js
@@ -1,4 +1,4 @@
-import Contract from 'ethers/contracts/contract.js';
+import { ContractFactory } from 'ethers/contract.js';
 
 export default function txDataByCompiled(
     abi,
@@ -8,11 +8,10 @@ export default function txDataByCompiled(
     // solc returns a string which is often passed instead of the json
     if (typeof abi === 'string') abi = JSON.parse(abi);
 
-    const deployTransaction = Contract.getDeployTransaction(
-        '0x' + bytecode,
-        abi,
-        ...args
-    );
+    // Construct a Contract Factory
+    const factory = new ContractFactory(abi, '0x' + bytecode);
+
+    const deployTransaction = factory.getDeployTransaction(...args);
 
     return deployTransaction.data;
 }


### PR DESCRIPTION
The are [breaking changes](https://docs.ethers.io/ethers.js/html/migration.html#deploying-contracts) from Ethers v3 to v4 with Contract deployment. Those issues have been addressed by utilizing the new ContractFactory provided by the latest Ethers v4.0.30