### PR TITLE
Upgrade ethers package to 5.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "eth-lib": "0.2.8",
     "ethereumjs-tx": "2.1.2",
     "ethereumjs-util": "6.2.0",
-    "ethers": "4.0.47",
+    "ethers": "5.0.8",
     "secp256k1": "4.0.2"
   }
 }

--- a/src/hash.js
+++ b/src/hash.js
@@ -1,6 +1,6 @@
 import {
-    keccak256 as solidityKeccak256
-} from 'ethers/utils/solidity.js';
+    utils as ethersUtils
+} from 'ethers';
 
 
 export function keccak256(params) {
@@ -15,7 +15,7 @@ export function keccak256(params) {
             values.push(p.value);
         });
     }
-    return solidityKeccak256(types, values);
+    return ethersUtils.solidityKeccak256(types, values);
 }
 
 export const SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/src/tx-data-by-compiled.js
+++ b/src/tx-data-by-compiled.js
@@ -1,4 +1,4 @@
-import { ContractFactory } from 'ethers/contract.js';
+import { ContractFactory } from 'ethers';
 
 export default function txDataByCompiled(
     abi,


### PR DESCRIPTION
Ethers version 5.x included changes to the structure of the package.  Two import statements need to be updated to be compatible with this new major release.

Additional details on the migration here:
https://docs.ethers.io/v5/migration/ethers-v4/