### PR TITLE
Update eccrypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "dependencies": {
     "@types/bn.js": "4.11.6",
     "babel-runtime": "6.26.0",
-    "eccrypto": "1.1.5",
+    "eccrypto": "1.1.6",
     "eth-lib": "0.2.8",
     "ethereumjs-tx": "2.1.2",
     "ethereumjs-util": "7.0.7",


### PR DESCRIPTION
This PR addresses https://www.npmjs.com/advisories/1648

`elliptic` was bumped from 6.5.3 to 6.5.4 in https://github.com/bitchan/eccrypto/pull/76 and the changes were published in `eccrypto@1.1.6` 

@pubkey can you have a look, please? 🙏 

Thanks!