### PR TITLE
Migrate from ethereumjs-tx to @ethereumjs/tx

### DIFF
--- a/dist/es/sign-transaction.js
+++ b/dist/es/sign-transaction.js
@@ -1,4 +1,5 @@
-import { Transaction } from 'ethereumjs-tx';
+
+import { Transaction } from '@ethereumjs/tx';
 import publicKeyByPrivateKey from './public-key-by-private-key';
 import { toAddress as addressByPublicKey } from './public-key';
 
@@ -11,8 +12,8 @@ export default function signTransaction(rawTx, privateKey) {
 
     var privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    var tx = new Transaction(rawTx);
-    tx.sign(privateKeyBuffer);
-    var serializedTx = tx.serialize().toString('hex');
+    var tx = Transaction.fromTxData(rawTx);
+    var signedTx = tx.sign(privateKeyBuffer);
+    var serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;
 }

--- a/dist/es/sign-transaction.js
+++ b/dist/es/sign-transaction.js
@@ -4,6 +4,8 @@ import publicKeyByPrivateKey from './public-key-by-private-key';
 import { toAddress as addressByPublicKey } from './public-key';
 
 export default function signTransaction(rawTx, privateKey) {
+    var txOptions = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
 
     // check if privateKey->address matches rawTx.from
     var publicKey = publicKeyByPrivateKey(privateKey);
@@ -12,7 +14,7 @@ export default function signTransaction(rawTx, privateKey) {
 
     var privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    var tx = Transaction.fromTxData(rawTx);
+    var tx = Transaction.fromTxData(rawTx, txOptions);
     var signedTx = tx.sign(privateKeyBuffer);
     var serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;

--- a/dist/lib/sign-transaction.js
+++ b/dist/lib/sign-transaction.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports['default'] = signTransaction;
 
-var _ethereumjsTx = require('ethereumjs-tx');
+var _tx = require('@ethereumjs/tx');
 
 var _publicKeyByPrivateKey = require('./public-key-by-private-key');
 
@@ -24,8 +24,8 @@ function signTransaction(rawTx, privateKey) {
 
     var privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    var tx = new _ethereumjsTx.Transaction(rawTx);
-    tx.sign(privateKeyBuffer);
-    var serializedTx = tx.serialize().toString('hex');
+    var tx = _tx.Transaction.fromTxData(rawTx);
+    var signedTx = tx.sign(privateKeyBuffer);
+    var serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;
 }

--- a/dist/lib/sign-transaction.js
+++ b/dist/lib/sign-transaction.js
@@ -16,6 +16,8 @@ var _publicKey = require('./public-key');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 function signTransaction(rawTx, privateKey) {
+    var txOptions = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
 
     // check if privateKey->address matches rawTx.from
     var publicKey = (0, _publicKeyByPrivateKey2['default'])(privateKey);
@@ -24,7 +26,7 @@ function signTransaction(rawTx, privateKey) {
 
     var privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    var tx = _tx.Transaction.fromTxData(rawTx);
+    var tx = _tx.Transaction.fromTxData(rawTx, txOptions);
     var signedTx = tx.sign(privateKeyBuffer);
     var serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;

--- a/package.json
+++ b/package.json
@@ -108,11 +108,11 @@
     "webpack-cli": "4.7.2"
   },
   "dependencies": {
+    "@ethereumjs/tx": "3.2.1",
     "@types/bn.js": "5.1.0",
     "babel-runtime": "6.26.0",
     "eccrypto": "1.1.6",
     "eth-lib": "0.2.8",
-    "ethereumjs-tx": "2.1.2",
     "ethereumjs-util": "7.0.10",
     "ethers": "5.3.1",
     "secp256k1": "4.0.2"

--- a/src/sign-transaction.js
+++ b/src/sign-transaction.js
@@ -1,4 +1,5 @@
-import { Transaction } from 'ethereumjs-tx';
+
+import { Transaction } from '@ethereumjs/tx';
 import publicKeyByPrivateKey from './public-key-by-private-key';
 import {
     toAddress as addressByPublicKey
@@ -17,8 +18,8 @@ export default function signTransaction(
 
     const privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    const tx = new Transaction(rawTx);
-    tx.sign(privateKeyBuffer);
-    const serializedTx = tx.serialize().toString('hex');
+    const tx = Transaction.fromTxData(rawTx);
+    const signedTx = tx.sign(privateKeyBuffer);
+    const serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;
 }

--- a/src/sign-transaction.js
+++ b/src/sign-transaction.js
@@ -7,7 +7,8 @@ import {
 
 export default function signTransaction(
     rawTx,
-    privateKey
+    privateKey,
+    txOptions = {}
 ) {
 
     // check if privateKey->address matches rawTx.from
@@ -18,7 +19,7 @@ export default function signTransaction(
 
     const privateKeyBuffer = Buffer.from(privateKey.replace(/^.{2}/g, ''), 'hex');
 
-    const tx = Transaction.fromTxData(rawTx);
+    const tx = Transaction.fromTxData(rawTx, txOptions);
     const signedTx = tx.sign(privateKeyBuffer);
     const serializedTx = signedTx.serialize().toString('hex');
     return serializedTx;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -43,7 +43,7 @@ describe('integration.test.js', () => {
                     state.accounts.push(identity);
                     const twoStripped = identity.privateKey.replace(/^.{2}/g, '');
                     return {
-                        secretKey: new Buffer(twoStripped, 'hex'),
+                        secretKey: Buffer.from(twoStripped, 'hex'),
                         balance: state.web3.utils.toWei('100', 'ether')
                     };
                 });
@@ -87,7 +87,7 @@ describe('integration.test.js', () => {
                 .fill(0)
                 .map(() => EthCrypto.createIdentity())
                 .map(identity => ({
-                    secretKey: new Buffer(identity.privateKey.replace(/^.{2}/g, ''), 'hex'),
+                    secretKey: Buffer.from(identity.privateKey.replace(/^.{2}/g, ''), 'hex'),
                     balance: web3.utils.toWei('100', 'ether')
                 }));
             web3.setProvider(ganache.provider({
@@ -101,7 +101,7 @@ describe('integration.test.js', () => {
             web3.transactionConfirmationBlocks = WEB3_CONFIRMATION_BLOCKS;
             web3.setProvider(ganache.provider({
                 accounts: [{
-                    secretKey: new Buffer(identity.privateKey.replace(/^.{2}/g, ''), 'hex'),
+                    secretKey: Buffer.from(identity.privateKey.replace(/^.{2}/g, ''), 'hex'),
                     balance: web3.utils.toWei('100', 'ether')
                 }]
             }));

--- a/test/tutorials/signed-data.test.js
+++ b/test/tutorials/signed-data.test.js
@@ -87,7 +87,7 @@ describe('signed-data.md', () => {
             to: contractAddress,
             nonce: 1,
             value: parseInt(web3.utils.toWei('3', 'ether')),
-            gas: 600000,
+            gasLimit: 600000,
             gasPrice: 20000000000
         };
         const serializedTx2 = EthCrypto.signTransaction(

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -284,21 +284,21 @@ describe('unit.test.js', () => {
                 const compressed = '03a34d6aef3eb42335fb3cacb59478c0b44c0bbeb8bb4ca427dbc7044157a5d24b';
                 const uncompressed = EthCrypto.publicKey.decompress(compressed);
                 assert.equal(typeof uncompressed, 'string');
-                const buf = new Buffer(uncompressed, 'hex');
+                const buf = Buffer.from(uncompressed, 'hex');
                 assert.equal(buf.length, 64);
             });
             it('should work when already uncompressed', () => {
                 const compressed = '04a34d6aef3eb42335fb3cacb59478c0b44c0bbeb8bb4ca427dbc7044157a5d24b4adf14868d8449c9b3e50d3d6338f3e5a2d3445abe679cddbe75cb893475806f';
                 const uncompressed = EthCrypto.publicKey.decompress(compressed);
                 assert.equal(typeof uncompressed, 'string');
-                const buf = new Buffer(uncompressed, 'hex');
+                const buf = Buffer.from(uncompressed, 'hex');
                 assert.equal(buf.length, 64);
             });
             it('should work when already uncompressed (no04)', () => {
                 const compressed = 'a34d6aef3eb42335fb3cacb59478c0b44c0bbeb8bb4ca427dbc7044157a5d24b4adf14868d8449c9b3e50d3d6338f3e5a2d3445abe679cddbe75cb893475806f';
                 const uncompressed = EthCrypto.publicKey.decompress(compressed);
                 assert.equal(typeof uncompressed, 'string');
-                const buf = new Buffer(uncompressed, 'hex');
+                const buf = Buffer.from(uncompressed, 'hex');
                 assert.equal(buf.length, 64);
             });
         });

--- a/tutorials/signed-data.md
+++ b/tutorials/signed-data.md
@@ -131,7 +131,7 @@ const rawTx2 = {
     to: contractAddress,
     nonce: 1, // increased by one
     value: parseInt(web3.utils.toWei('3', 'ether')),
-    gas: 600000,
+    gasLimit: 600000,
     gasPrice: 20000000000
 };
 const serializedTx2 = EthCrypto.signTransaction(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,5 @@
 import BigNumber = require('bn.js');
+import { TxOptions } from '@ethereumjs/tx';
 
 type createIdentityType = (entropy?: Buffer) => {
     privateKey: string,
@@ -69,7 +70,8 @@ export const cipher: cipherType;
 
 type signTransactionType = (
     rawTx: RawTx,
-    privateKey: string
+    privateKey: string,
+    txOptions?: TxOptions
 ) => string;
 export const signTransaction: signTransactionType;
 


### PR DESCRIPTION
Fixes #425 and #426

~~I'm trying to migrate from `ethereumjs-tx` to `@ethereumjs/tx`. It almost works, only `test/tutorials/signed-data.test.js` fails with the error: `base fee exceeds gas limit`. Any idea how to fix it?~~ Fixed in https://github.com/pubkey/eth-crypto/pull/445/commits/2890c19c38943fe8a306adcf9eaf927eb77e6ec8

Thanks!