### PR TITLE
Fix: Migrate ethers from v5 to v6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ log.txt
 package-lock.json
 gen/
 test_tmp/
+
+./dist
+.dist/
+.dist

--- a/dist/es/cipher.js
+++ b/dist/es/cipher.js
@@ -1,4 +1,5 @@
 import { compress, decompress } from './public-key';
+
 export function stringify(cipher) {
   if (typeof cipher === 'string') return cipher;
 
@@ -12,7 +13,6 @@ export function stringify(cipher) {
   // 32bit
   Buffer.from(cipher.ciphertext, 'hex') // var bit
   ]);
-
   return ret.toString('hex');
 }
 export function parse(str) {

--- a/dist/es/create-identity.js
+++ b/dist/es/create-identity.js
@@ -1,7 +1,10 @@
-import { utils as ethersUtils, Wallet } from 'ethers';
-import { stripHexPrefix } from 'ethereumjs-util';
+import * as ethersUtils from 'ethers';
+import { publicKeyByPrivateKey } from './public-key-by-private-key';
+// import { stripHexPrefix } from 'ethereumjs-util';
+
 var MIN_ENTROPY_SIZE = 128;
-var keccak256 = ethersUtils.keccak256;
+
+var { Wallet, keccak256 } = ethersUtils;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -32,8 +35,7 @@ export function createIdentity(entropy) {
   var wallet = new Wallet(privateKey);
   var identity = {
     privateKey: privateKey,
-    // remove trailing '0x04'
-    publicKey: stripHexPrefix(wallet.publicKey).slice(2),
+    publicKey: publicKeyByPrivateKey(privateKey),
     address: wallet.address
   };
   return identity;

--- a/dist/es/hash.js
+++ b/dist/es/hash.js
@@ -1,4 +1,4 @@
-import { utils as ethersUtils } from 'ethers';
+import * as ethersUtils from 'ethers';
 export function keccak256(params) {
   var types = [];
   var values = [];
@@ -11,6 +11,6 @@ export function keccak256(params) {
       values.push(p.value);
     });
   }
-  return ethersUtils.solidityKeccak256(types, values);
+  return ethersUtils.solidityPackedKeccak256(types, values);
 }
 export var SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/dist/es/vrs.js
+++ b/dist/es/vrs.js
@@ -1,11 +1,11 @@
-import { utils as ethersUtils } from 'ethers';
+import * as ethersUtils from 'ethers';
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 export function fromString(hexString) {
-  var arr = ethersUtils.splitSignature(hexString);
+  var arr = ethersUtils.Signature.from(hexString);
   return {
     // convert "v" to hex
     v: "0x".concat(arr.v.toString(16)),
@@ -20,5 +20,7 @@ export function fromString(hexString) {
  * @return {string} hexString
  */
 export function toString(sig) {
-  return ethersUtils.joinSignature(sig);
+  // migrating from v5 to v6:
+  // https://docs.ethers.org/v6/migrating/#migrate-signatures
+  return ethersUtils.Signature.from(sig).serialized;
 }

--- a/dist/lib/cipher.js
+++ b/dist/lib/cipher.js
@@ -19,7 +19,6 @@ function stringify(cipher) {
   // 32bit
   Buffer.from(cipher.ciphertext, 'hex') // var bit
   ]);
-
   return ret.toString('hex');
 }
 function parse(str) {

--- a/dist/lib/create-identity.js
+++ b/dist/lib/create-identity.js
@@ -1,14 +1,20 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.createIdentity = createIdentity;
 exports.createPrivateKey = createPrivateKey;
-var _ethers = require("ethers");
-var _ethereumjsUtil = require("ethereumjs-util");
+var ethersUtils = _interopRequireWildcard(require("ethers"));
+var _publicKeyByPrivateKey = require("./public-key-by-private-key");
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+// import { stripHexPrefix } from 'ethereumjs-util';
+
 var MIN_ENTROPY_SIZE = 128;
-var keccak256 = _ethers.utils.keccak256;
+var keccak256 = ethersUtils.keccak256,
+  Wallet = ethersUtils.Wallet;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -22,8 +28,8 @@ function createPrivateKey(entropy) {
     var outerHex = keccak256(entropy);
     return outerHex;
   } else {
-    var innerHex = keccak256(_ethers.utils.concat([_ethers.utils.randomBytes(32), _ethers.utils.randomBytes(32)]));
-    var middleHex = _ethers.utils.concat([_ethers.utils.concat([_ethers.utils.randomBytes(32), innerHex]), _ethers.utils.randomBytes(32)]);
+    var innerHex = keccak256(ethersUtils.concat([ethersUtils.randomBytes(32), ethersUtils.randomBytes(32)]));
+    var middleHex = ethersUtils.concat([ethersUtils.concat([ethersUtils.randomBytes(32), innerHex]), ethersUtils.randomBytes(32)]);
     var _outerHex = keccak256(middleHex);
     return _outerHex;
   }
@@ -36,11 +42,10 @@ function createPrivateKey(entropy) {
  */
 function createIdentity(entropy) {
   var privateKey = createPrivateKey(entropy);
-  var wallet = new _ethers.Wallet(privateKey);
+  var wallet = new Wallet(privateKey);
   var identity = {
     privateKey: privateKey,
-    // remove trailing '0x04'
-    publicKey: (0, _ethereumjsUtil.stripHexPrefix)(wallet.publicKey).slice(2),
+    publicKey: (0, _publicKeyByPrivateKey.publicKeyByPrivateKey)(privateKey),
     address: wallet.address
   };
   return identity;

--- a/dist/lib/encrypt-with-public-key.js
+++ b/dist/lib/encrypt-with-public-key.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.encryptWithPublicKey = encryptWithPublicKey;
 var _eccrypto = require("eccrypto");
 var _publicKey = require("./public-key");
+
 function encryptWithPublicKey(publicKey, message, opts) {
   // ensure its an uncompressed publicKey
   publicKey = (0, _publicKey.decompress)(publicKey);

--- a/dist/lib/hash.js
+++ b/dist/lib/hash.js
@@ -1,11 +1,14 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.SIGN_PREFIX = void 0;
 exports.keccak256 = keccak256;
-var _ethers = require("ethers");
+var ethersUtils = _interopRequireWildcard(require("ethers"));
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 function keccak256(params) {
   var types = [];
   var values = [];
@@ -18,7 +21,6 @@ function keccak256(params) {
       values.push(p.value);
     });
   }
-  return _ethers.utils.solidityKeccak256(types, values);
+  return ethersUtils.solidityPackedKeccak256(types, values);
 }
-var SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';
-exports.SIGN_PREFIX = SIGN_PREFIX;
+var SIGN_PREFIX = exports.SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -90,9 +90,9 @@ var vrs = _interopRequireWildcard(require("./vrs"));
 exports.vrs = vrs;
 var util = _interopRequireWildcard(require("./util"));
 exports.util = util;
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-var _default = {
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+var _default = exports["default"] = {
   createIdentity: _createIdentity.createIdentity,
   publicKey: publicKey,
   decryptWithPrivateKey: _decryptWithPrivateKey.decryptWithPrivateKey,
@@ -110,4 +110,3 @@ var _default = {
   vrs: vrs,
   util: util
 };
-exports["default"] = _default;

--- a/dist/lib/vrs.js
+++ b/dist/lib/vrs.js
@@ -1,18 +1,21 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.fromString = fromString;
 exports.toString = toString;
-var _ethers = require("ethers");
+var ethersUtils = _interopRequireWildcard(require("ethers"));
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 function fromString(hexString) {
-  var arr = _ethers.utils.splitSignature(hexString);
+  var arr = ethersUtils.Signature.from(hexString);
   return {
     // convert "v" to hex
     v: "0x".concat(arr.v.toString(16)),
@@ -27,5 +30,7 @@ function fromString(hexString) {
  * @return {string} hexString
  */
 function toString(sig) {
-  return _ethers.utils.joinSignature(sig);
+  // migrating from v5 to v6:
+  // https://docs.ethers.org/v6/migrating/#migrate-signatures
+  return ethersUtils.Signature.from(sig).serialized;
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@types/bn.js": "5.1.5",
     "eccrypto": "1.1.6",
     "ethereumjs-util": "7.1.5",
-    "ethers": "5.7.2",
+    "ethers": "^6.13.1",
     "secp256k1": "5.0.0"
   }
 }

--- a/src/create-identity.js
+++ b/src/create-identity.js
@@ -1,8 +1,9 @@
-import { utils as ethersUtils, Wallet } from 'ethers';
-import { stripHexPrefix } from 'ethereumjs-util';
+import * as ethersUtils from 'ethers';
+import { publicKeyByPrivateKey } from './public-key-by-private-key';
+// import { stripHexPrefix } from 'ethereumjs-util';
 
 const MIN_ENTROPY_SIZE = 128;
-const { keccak256 } = ethersUtils;
+const { keccak256, Wallet } = ethersUtils;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -36,8 +37,7 @@ export function createIdentity(entropy) {
     const wallet = new Wallet(privateKey);
     const identity = {
         privateKey: privateKey,
-        // remove trailing '0x04'
-        publicKey: stripHexPrefix(wallet.publicKey).slice(2),
+        publicKey: publicKeyByPrivateKey(privateKey),
         address: wallet.address,
     };
     return identity;

--- a/src/hash.js
+++ b/src/hash.js
@@ -1,7 +1,4 @@
-import {
-    utils as ethersUtils
-} from 'ethers';
-
+import * as ethersUtils from 'ethers';
 
 export function keccak256(params) {
     const types = [];
@@ -9,13 +6,13 @@ export function keccak256(params) {
     if (!Array.isArray(params)) {
         types.push('string');
         values.push(params);
-    }else {
-        params.forEach(p => {
+    } else {
+        params.forEach((p) => {
             types.push(p.type);
             values.push(p.value);
         });
     }
-    return ethersUtils.solidityKeccak256(types, values);
+    return ethersUtils.solidityPackedKeccak256(types, values);
 }
 
 export const SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/src/vrs.js
+++ b/src/vrs.js
@@ -1,13 +1,11 @@
-import {
-    utils as ethersUtils
-} from 'ethers';
+import * as ethersUtils from 'ethers';
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 export function fromString(hexString) {
-    const arr = ethersUtils.splitSignature(hexString);
+    const arr = ethersUtils.Signature.from(hexString);
     return {
         // convert "v" to hex
         v: `0x${arr.v.toString(16)}`,
@@ -22,5 +20,7 @@ export function fromString(hexString) {
  * @return {string} hexString
  */
 export function toString(sig) {
-    return ethersUtils.joinSignature(sig);
+    // migrating from v5 to v6:
+    // https://docs.ethers.org/v6/migrating/#migrate-signatures
+    return ethersUtils.Signature.from(sig).serialized;
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -15,7 +15,9 @@ const HEX_STRING = '0x55030130e79efc853f8644d32c11a58d47018cc3a08a16ac4fb9c09af4
 describe('unit.test.js', () => {
     describe('.createIdentity()', () => {
         it('should create an identity', () => {
+            console.log('attemt to create identity');
             const ident = EthCrypto.createIdentity();
+            console.log('new identity created', ident);
             assert.equal(typeof ident.privateKey, 'string');
             assert.equal(typeof ident.publicKey, 'string');
             assert.equal(typeof ident.address, 'string');


### PR DESCRIPTION
This PR follows the migration guide published by `ethers` to migrate from v5 ([link here](https://docs.ethers.org/v6/migrating/))

### Changes introduced:

| # | function | v5 | v6 |
|-----|-------------|---------|--------------------------------------------------------------------------------------|
| 1 | `vrs.fromString`  | `splitSig = splitSignature(sigBytes)` | `splitSig = ethers.Signature.from(sigBytes)` |
| 2 | `vrs.toString`  | `ethersUtils.joinSignature(sig)` | `ethersUtils.Signature.from(sig).serialized` |
| 3 |`hash.keccak256` | `ethersUtils.solidityKeccak256` | `ethersUtils.solidityPackedKeccak256` |