### PR TITLE
Upgrade to ethers 6

### DIFF
--- a/dist/es/create-identity.js
+++ b/dist/es/create-identity.js
@@ -1,7 +1,8 @@
-import { utils as ethersUtils, Wallet } from 'ethers';
+import * as ethers from 'ethers';
 import { stripHexPrefix } from 'ethereumjs-util';
 var MIN_ENTROPY_SIZE = 128;
-var keccak256 = ethersUtils.keccak256;
+var keccak256 = ethers.keccak256,
+  Wallet = ethers.Wallet;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -15,8 +16,8 @@ export function createPrivateKey(entropy) {
     var outerHex = keccak256(entropy);
     return outerHex;
   } else {
-    var innerHex = keccak256(ethersUtils.concat([ethersUtils.randomBytes(32), ethersUtils.randomBytes(32)]));
-    var middleHex = ethersUtils.concat([ethersUtils.concat([ethersUtils.randomBytes(32), innerHex]), ethersUtils.randomBytes(32)]);
+    var innerHex = keccak256(ethers.concat([ethers.randomBytes(32), ethers.randomBytes(32)]));
+    var middleHex = ethers.concat([ethers.concat([ethers.randomBytes(32), innerHex]), ethers.randomBytes(32)]);
     var _outerHex = keccak256(middleHex);
     return _outerHex;
   }
@@ -33,7 +34,7 @@ export function createIdentity(entropy) {
   var identity = {
     privateKey: privateKey,
     // remove trailing '0x04'
-    publicKey: stripHexPrefix(wallet.publicKey).slice(2),
+    publicKey: stripHexPrefix(wallet.signingKey.publicKey).slice(2),
     address: wallet.address
   };
   return identity;

--- a/dist/es/hash.js
+++ b/dist/es/hash.js
@@ -1,4 +1,4 @@
-import { utils as ethersUtils } from 'ethers';
+import * as ethers from 'ethers';
 export function keccak256(params) {
   var types = [];
   var values = [];
@@ -11,6 +11,6 @@ export function keccak256(params) {
       values.push(p.value);
     });
   }
-  return ethersUtils.solidityKeccak256(types, values);
+  return ethers.solidityPackedKeccak256(types, values);
 }
 export var SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/dist/es/tx-data-by-compiled.js
+++ b/dist/es/tx-data-by-compiled.js
@@ -6,7 +6,6 @@ export function txDataByCompiled(abi, bytecode, args) {
   }
   var iface = new Interface(abi);
   var encodedArgs = iface.encodeDeploy(args);
-  console.log('encodedArgs: ', bytecode);
   var data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
   return data;
 }

--- a/dist/es/tx-data-by-compiled.js
+++ b/dist/es/tx-data-by-compiled.js
@@ -6,6 +6,7 @@ export function txDataByCompiled(abi, bytecode, args) {
   }
   var iface = new Interface(abi);
   var encodedArgs = iface.encodeDeploy(args);
+  console.log('encodedArgs: ', bytecode);
   var data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
   return data;
 }

--- a/dist/es/tx-data-by-compiled.js
+++ b/dist/es/tx-data-by-compiled.js
@@ -1,11 +1,11 @@
-import _toConsumableArray from "@babel/runtime/helpers/toConsumableArray";
-import { ContractFactory } from 'ethers';
+import { Interface, concat } from 'ethers';
 export function txDataByCompiled(abi, bytecode, args) {
-  // solc returns a string which is often passed instead of the json
-  if (typeof abi === 'string') abi = JSON.parse(abi);
-
-  // Construct a Contract Factory
-  var factory = new ContractFactory(abi, '0x' + bytecode);
-  var deployTransaction = factory.getDeployTransaction.apply(factory, _toConsumableArray(args));
-  return deployTransaction.data;
+  // solc returns a string which is often passed instead of the JSON
+  if (typeof abi === 'string') {
+    abi = JSON.parse(abi);
+  }
+  var iface = new Interface(abi);
+  var encodedArgs = iface.encodeDeploy(args);
+  var data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
+  return data;
 }

--- a/dist/es/vrs.js
+++ b/dist/es/vrs.js
@@ -1,11 +1,11 @@
-import { utils as ethersUtils } from 'ethers';
+import * as ethers from 'ethers';
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 export function fromString(hexString) {
-  var arr = ethersUtils.splitSignature(hexString);
+  var arr = ethers.Signature.from(hexString);
   return {
     // convert "v" to hex
     v: "0x".concat(arr.v.toString(16)),
@@ -20,5 +20,5 @@ export function fromString(hexString) {
  * @return {string} hexString
  */
 export function toString(sig) {
-  return ethersUtils.joinSignature(sig);
+  return ethers.Signature.from(sig).serialized;
 }

--- a/dist/lib/create-identity.js
+++ b/dist/lib/create-identity.js
@@ -1,14 +1,18 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.createIdentity = createIdentity;
 exports.createPrivateKey = createPrivateKey;
-var _ethers = require("ethers");
+var ethers = _interopRequireWildcard(require("ethers"));
 var _ethereumjsUtil = require("ethereumjs-util");
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 var MIN_ENTROPY_SIZE = 128;
-var keccak256 = _ethers.utils.keccak256;
+var keccak256 = ethers.keccak256,
+  Wallet = ethers.Wallet;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -22,8 +26,8 @@ function createPrivateKey(entropy) {
     var outerHex = keccak256(entropy);
     return outerHex;
   } else {
-    var innerHex = keccak256(_ethers.utils.concat([_ethers.utils.randomBytes(32), _ethers.utils.randomBytes(32)]));
-    var middleHex = _ethers.utils.concat([_ethers.utils.concat([_ethers.utils.randomBytes(32), innerHex]), _ethers.utils.randomBytes(32)]);
+    var innerHex = keccak256(ethers.concat([ethers.randomBytes(32), ethers.randomBytes(32)]));
+    var middleHex = ethers.concat([ethers.concat([ethers.randomBytes(32), innerHex]), ethers.randomBytes(32)]);
     var _outerHex = keccak256(middleHex);
     return _outerHex;
   }
@@ -36,11 +40,11 @@ function createPrivateKey(entropy) {
  */
 function createIdentity(entropy) {
   var privateKey = createPrivateKey(entropy);
-  var wallet = new _ethers.Wallet(privateKey);
+  var wallet = new Wallet(privateKey);
   var identity = {
     privateKey: privateKey,
     // remove trailing '0x04'
-    publicKey: (0, _ethereumjsUtil.stripHexPrefix)(wallet.publicKey).slice(2),
+    publicKey: (0, _ethereumjsUtil.stripHexPrefix)(wallet.signingKey.publicKey).slice(2),
     address: wallet.address
   };
   return identity;

--- a/dist/lib/hash.js
+++ b/dist/lib/hash.js
@@ -1,11 +1,14 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.SIGN_PREFIX = void 0;
 exports.keccak256 = keccak256;
-var _ethers = require("ethers");
+var ethers = _interopRequireWildcard(require("ethers"));
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 function keccak256(params) {
   var types = [];
   var values = [];
@@ -18,6 +21,6 @@ function keccak256(params) {
       values.push(p.value);
     });
   }
-  return _ethers.utils.solidityKeccak256(types, values);
+  return ethers.solidityPackedKeccak256(types, values);
 }
 var SIGN_PREFIX = exports.SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/dist/lib/tx-data-by-compiled.js
+++ b/dist/lib/tx-data-by-compiled.js
@@ -1,18 +1,17 @@
 "use strict";
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.txDataByCompiled = txDataByCompiled;
-var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
 var _ethers = require("ethers");
 function txDataByCompiled(abi, bytecode, args) {
-  // solc returns a string which is often passed instead of the json
-  if (typeof abi === 'string') abi = JSON.parse(abi);
-
-  // Construct a Contract Factory
-  var factory = new _ethers.ContractFactory(abi, '0x' + bytecode);
-  var deployTransaction = factory.getDeployTransaction.apply(factory, (0, _toConsumableArray2["default"])(args));
-  return deployTransaction.data;
+  // solc returns a string which is often passed instead of the JSON
+  if (typeof abi === 'string') {
+    abi = JSON.parse(abi);
+  }
+  var iface = new _ethers.Interface(abi);
+  var encodedArgs = iface.encodeDeploy(args);
+  var data = (0, _ethers.concat)(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
+  return data;
 }

--- a/dist/lib/tx-data-by-compiled.js
+++ b/dist/lib/tx-data-by-compiled.js
@@ -12,6 +12,7 @@ function txDataByCompiled(abi, bytecode, args) {
   }
   var iface = new _ethers.Interface(abi);
   var encodedArgs = iface.encodeDeploy(args);
+  console.log('encodedArgs: ', bytecode);
   var data = (0, _ethers.concat)(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
   return data;
 }

--- a/dist/lib/tx-data-by-compiled.js
+++ b/dist/lib/tx-data-by-compiled.js
@@ -12,7 +12,6 @@ function txDataByCompiled(abi, bytecode, args) {
   }
   var iface = new _ethers.Interface(abi);
   var encodedArgs = iface.encodeDeploy(args);
-  console.log('encodedArgs: ', bytecode);
   var data = (0, _ethers.concat)(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
   return data;
 }

--- a/dist/lib/vrs.js
+++ b/dist/lib/vrs.js
@@ -1,18 +1,21 @@
 "use strict";
 
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.fromString = fromString;
 exports.toString = toString;
-var _ethers = require("ethers");
+var ethers = _interopRequireWildcard(require("ethers"));
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 function fromString(hexString) {
-  var arr = _ethers.utils.splitSignature(hexString);
+  var arr = ethers.Signature.from(hexString);
   return {
     // convert "v" to hex
     v: "0x".concat(arr.v.toString(16)),
@@ -27,5 +30,5 @@ function fromString(hexString) {
  * @return {string} hexString
  */
 function toString(sig) {
-  return _ethers.utils.joinSignature(sig);
+  return ethers.Signature.from(sig).serialized;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-crypto",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Cryptographic functions for ethereum and how to use them with web3 and solidity",
   "keywords": [
     "ethereum",
@@ -102,7 +102,7 @@
     "@types/bn.js": "5.1.6",
     "eccrypto": "1.1.6",
     "ethereumjs-util": "7.1.5",
-    "ethers": "5.8.0",
+    "ethers": "6.13.5",
     "secp256k1": "5.0.1"
   }
 }

--- a/src/create-identity.js
+++ b/src/create-identity.js
@@ -1,8 +1,8 @@
-import { utils as ethersUtils, Wallet } from 'ethers';
+import * as ethers from 'ethers';
 import { stripHexPrefix } from 'ethereumjs-util';
 
 const MIN_ENTROPY_SIZE = 128;
-const { keccak256 } = ethersUtils;
+const { keccak256, Wallet } = ethers;
 
 /**
  * create a privateKey from the given entropy or a new one
@@ -19,8 +19,8 @@ export function createPrivateKey(entropy) {
         const outerHex = keccak256(entropy);
         return outerHex;
     } else {
-        const innerHex = keccak256(ethersUtils.concat([ethersUtils.randomBytes(32), ethersUtils.randomBytes(32)]));
-        const middleHex = ethersUtils.concat([ethersUtils.concat([ethersUtils.randomBytes(32), innerHex]), ethersUtils.randomBytes(32)]);
+        const innerHex = keccak256(ethers.concat([ethers.randomBytes(32), ethers.randomBytes(32)]));
+        const middleHex = ethers.concat([ethers.concat([ethers.randomBytes(32), innerHex]), ethers.randomBytes(32)]);
         const outerHex = keccak256(middleHex);
         return outerHex;
     }
@@ -37,7 +37,7 @@ export function createIdentity(entropy) {
     const identity = {
         privateKey: privateKey,
         // remove trailing '0x04'
-        publicKey: stripHexPrefix(wallet.publicKey).slice(2),
+        publicKey: stripHexPrefix(wallet.signingKey.publicKey).slice(2),
         address: wallet.address,
     };
     return identity;

--- a/src/hash.js
+++ b/src/hash.js
@@ -1,6 +1,4 @@
-import {
-    utils as ethersUtils
-} from 'ethers';
+import * as ethers from 'ethers';
 
 
 export function keccak256(params) {
@@ -15,7 +13,7 @@ export function keccak256(params) {
             values.push(p.value);
         });
     }
-    return ethersUtils.solidityKeccak256(types, values);
+    return ethers.solidityPackedKeccak256(types, values);
 }
 
 export const SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';

--- a/src/tx-data-by-compiled.js
+++ b/src/tx-data-by-compiled.js
@@ -1,14 +1,14 @@
 import { Interface, concat } from 'ethers';
 
 export function txDataByCompiled(abi, bytecode, args) {
-  // solc returns a string which is often passed instead of the JSON
-  if (typeof abi === 'string') {
-    abi = JSON.parse(abi);
-  }
+    // solc returns a string which is often passed instead of the JSON
+    if (typeof abi === 'string') {
+        abi = JSON.parse(abi);
+    }
 
-  const iface = new Interface(abi);
-  const encodedArgs = iface.encodeDeploy(args);
-  const data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
+    const iface = new Interface(abi);
+    const encodedArgs = iface.encodeDeploy(args);
+    const data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
 
-  return data;
+    return data;
 }

--- a/src/tx-data-by-compiled.js
+++ b/src/tx-data-by-compiled.js
@@ -1,17 +1,14 @@
-import { ContractFactory } from 'ethers';
+import { Interface, concat } from 'ethers';
 
-export function txDataByCompiled(
-    abi,
-    bytecode,
-    args
-) {
-    // solc returns a string which is often passed instead of the json
-    if (typeof abi === 'string') abi = JSON.parse(abi);
+export function txDataByCompiled(abi, bytecode, args) {
+  // solc returns a string which is often passed instead of the JSON
+  if (typeof abi === 'string') {
+    abi = JSON.parse(abi);
+  }
 
-    // Construct a Contract Factory
-    const factory = new ContractFactory(abi, '0x' + bytecode);
+  const iface = new Interface(abi);
+  const encodedArgs = iface.encodeDeploy(args);
+  const data = concat(['0x' + bytecode.replace(/^0x/, ''), encodedArgs]);
 
-    const deployTransaction = factory.getDeployTransaction(...args);
-
-    return deployTransaction.data;
+  return data;
 }

--- a/src/vrs.js
+++ b/src/vrs.js
@@ -1,13 +1,11 @@
-import {
-    utils as ethersUtils
-} from 'ethers';
+import * as ethers from 'ethers';
 /**
  * split signature-hex into parts
  * @param  {string} hexString
  * @return {{v: string, r: string, s: string}}
  */
 export function fromString(hexString) {
-    const arr = ethersUtils.splitSignature(hexString);
+    const arr = ethers.Signature.from(hexString);
     return {
         // convert "v" to hex
         v: `0x${arr.v.toString(16)}`,
@@ -22,5 +20,5 @@ export function fromString(hexString) {
  * @return {string} hexString
  */
 export function toString(sig) {
-    return ethersUtils.joinSignature(sig);
+    return ethers.Signature.from(sig).serialized;
 }

--- a/test/tutorials/signed-data.test.js
+++ b/test/tutorials/signed-data.test.js
@@ -47,6 +47,8 @@ describe('signed-data.md', () => {
             [creatorIdentity.address] // constructor-arguments
         );
 
+        console.log(createCode);
+
         // create create-tx
         const rawTx = {
             from: creatorIdentity.address,


### PR DESCRIPTION
Used the ethers [migration guide](https://docs.ethers.org/v6/migrating/) but it doesn't appear to be quite comprehensive.

The most notable change is the different approach to implementing `txDataByCompiled()`. In ethers v6, `contractFactory.getDeployTransaction()` [returns a promise](https://docs.ethers.org/v6/api/contract/#ContractFactory-getDeployTransaction). So using that would cause a breaking change in this library and possibly require a major version bump, which seemed excessive for that one thing. I also snuck in a change to handle the case where the `bytecode` argument is already `0x` prefixed.

The other changes were all very straightforward, just functions exported from slightly different places from ethers, or named slightly differently.