### PR TITLE
Add README deprecation notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]  
+> The library is deprecated. It is suggested to use [ethers](https://ethers.org/) or [viem](https://viem.sh) instead.
+
 <p align="center">
     <a href="https://twitter.com/pubkeypubkey">
         <img src="https://img.shields.io/twitter/follow/pubkeypubkey.svg?style=social&logo=twitter"


### PR DESCRIPTION
This library seems to be deprecated (issues are closed, etc). Using ethers or viem directly are better choices.

eth-crypto is using old, non-secure cryptography, through ethers v5. Efforts to upgrade to v6 have failed thrice: #901, #858, #836. That poses a security risk to users.

Renovate bot is technically upgrading dependencies, but it is useless overall, because it's upgrading irrelevant stuff instead of ethers.