### PR TITLE
CHANGE replace ethereumjs-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "concurrently": "9.2.0",
     "convert-hrtime": "5.0.0",
     "cross-env": "7.0.3",
+    "crypto-browserify": "3.12.1",
     "dependency-check": "4.1.0",
     "disc": "1.3.3",
     "eslint": "8.57.1",
@@ -85,6 +86,7 @@
     "rimraf": "4.4.1",
     "solhint": "5.0.5",
     "solidity-cli": "1.0.3",
+    "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "5.3.14",
     "ts-node": "10.9.2",
     "typescript": "5.5.4",
@@ -92,16 +94,14 @@
     "web3": "1.10.4",
     "webpack": "5.75.0",
     "webpack-bundle-analyzer": "4.10.2",
-    "webpack-cli": "5.1.4",
-    "stream-browserify": "3.0.0",
-    "crypto-browserify": "3.12.1"
+    "webpack-cli": "5.1.4"
   },
   "dependencies": {
     "@babel/runtime": "7.27.6",
     "@ethereumjs/tx": "3.5.2",
+    "@ethereumjs/util": "10.0.0",
     "@types/bn.js": "5.2.0",
     "eccrypto": "1.1.6",
-    "ethereumjs-util": "7.1.5",
     "ethers": "5.8.0",
     "secp256k1": "5.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "terser-webpack-plugin": "5.3.14",
     "ts-node": "10.9.2",
     "typescript": "5.5.4",
-    "uglify-es": "3.3.9",
+    "uglify-js": "3.19.3",
     "web3": "1.10.4",
     "webpack": "5.75.0",
     "webpack-bundle-analyzer": "4.10.2",

--- a/src/calculate-contract-address.js
+++ b/src/calculate-contract-address.js
@@ -1,8 +1,10 @@
 import {
     generateAddress,
     toChecksumAddress,
-    toBuffer
-} from 'ethereumjs-util';
+    hexToBytes,
+    bytesToHex,
+    intToHex
+} from '@ethereumjs/util';
 import {
     addLeading0x
 } from './util';
@@ -13,9 +15,9 @@ export function calculateContractAddress(
     nonce
 ) {
     const addressBuffer = generateAddress(
-        toBuffer(addLeading0x(creatorAddress)),
-        toBuffer(nonce)
+        hexToBytes(addLeading0x(creatorAddress)),
+        hexToBytes(intToHex(nonce))
     );
-    const address = addressBuffer.toString('hex');
+    const address = bytesToHex(addressBuffer);
     return toChecksumAddress(addLeading0x(address));
 }

--- a/src/create-identity.js
+++ b/src/create-identity.js
@@ -1,5 +1,5 @@
 import { utils as ethersUtils, Wallet } from 'ethers';
-import { stripHexPrefix } from 'ethereumjs-util';
+import { stripHexPrefix } from '@ethereumjs/util';
 
 const MIN_ENTROPY_SIZE = 128;
 const { keccak256 } = ethersUtils;

--- a/src/public-key-by-private-key.js
+++ b/src/public-key-by-private-key.js
@@ -1,9 +1,11 @@
 import {
     privateToPublic,
-    toBuffer
-} from 'ethereumjs-util';
+    hexToBytes,
+    bytesToHex
+} from '@ethereumjs/util';
 import {
-    addLeading0x
+    addLeading0x,
+    removeLeading0x
 } from './util';
 
 /**
@@ -14,6 +16,7 @@ import {
  */
 export function publicKeyByPrivateKey(privateKey) {
     privateKey = addLeading0x(privateKey);
-    const publicKeyBuffer = privateToPublic(toBuffer(privateKey));
-    return publicKeyBuffer.toString('hex');
+    const publicKeyBuffer = privateToPublic(hexToBytes(privateKey));
+    const ret = removeLeading0x(bytesToHex(publicKeyBuffer));
+    return ret;
 }

--- a/src/public-key.js
+++ b/src/public-key.js
@@ -4,8 +4,9 @@ import {
 import {
     pubToAddress,
     toChecksumAddress,
-    toBuffer
-} from 'ethereumjs-util';
+    hexToBytes,
+    bytesToHex
+} from '@ethereumjs/util';
 import {
     hexToUnit8Array,
     uint8ArrayToHex,
@@ -50,8 +51,11 @@ export function toAddress(publicKey) {
 
     // normalize key
     publicKey = decompress(publicKey);
+    publicKey = addLeading0x(publicKey);
 
-    const addressBuffer = pubToAddress(toBuffer(addLeading0x(publicKey)));
-    const checkSumAdress = toChecksumAddress(addLeading0x(addressBuffer.toString('hex')));
+    const addressBuffer = pubToAddress(hexToBytes(publicKey));
+    const address = bytesToHex(addressBuffer);
+
+    const checkSumAdress = toChecksumAddress(addLeading0x(address));
     return checkSumAdress;
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -65,7 +65,6 @@ describe('unit.test.js', () => {
     describe('.publicKeyByPrivateKey()', () => {
         describe('positive', () => {
             it('should give the correct publicKey', () => {
-                console.dir(EthCrypto);
                 const publicKey = EthCrypto.publicKeyByPrivateKey(TEST_DATA.privateKey);
                 assert.equal(publicKey, TEST_DATA.publicKey);
             });


### PR DESCRIPTION
`ethereumjs-util` was outdated, so we use `@ethereumjs/util` instead.