### PR TITLE
fix(deps): drop secp256k1 package to clear consumer npm-audit alerts

### DIFF
--- a/dist/es/public-key.js
+++ b/dist/es/public-key.js
@@ -1,17 +1,17 @@
-import { publicKeyConvert } from 'secp256k1';
+import { secp256k1 } from 'ethereum-cryptography/secp256k1';
 import { pubToAddress, toChecksumAddress, hexToBytes, bytesToHex } from '@ethereumjs/util';
 import { hexToUnit8Array, uint8ArrayToHex, addLeading0x } from './util';
 export function compress(startsWith04) {
   // add trailing 04 if not done before
   var testBuffer = Buffer.from(startsWith04, 'hex');
   if (testBuffer.length === 64) startsWith04 = '04' + startsWith04;
-  return uint8ArrayToHex(publicKeyConvert(hexToUnit8Array(startsWith04), true));
+  return uint8ArrayToHex(secp256k1.ProjectivePoint.fromHex(hexToUnit8Array(startsWith04)).toRawBytes(true));
 }
 export function decompress(startsWith02Or03) {
   // if already decompressed an not has trailing 04
   var testBuffer = Buffer.from(startsWith02Or03, 'hex');
   if (testBuffer.length === 64) startsWith02Or03 = '04' + startsWith02Or03;
-  var decompressed = uint8ArrayToHex(publicKeyConvert(hexToUnit8Array(startsWith02Or03), false));
+  var decompressed = uint8ArrayToHex(secp256k1.ProjectivePoint.fromHex(hexToUnit8Array(startsWith02Or03)).toRawBytes(false));
 
   // remove trailing 04
   decompressed = decompressed.substring(2);

--- a/dist/es/recover-public-key.js
+++ b/dist/es/recover-public-key.js
@@ -1,4 +1,4 @@
-import { ecdsaRecover } from 'secp256k1';
+import { secp256k1 } from 'ethereum-cryptography/secp256k1';
 import { removeLeading0x, hexToUnit8Array, uint8ArrayToHex } from './util';
 
 /**
@@ -15,7 +15,8 @@ export function recoverPublicKey(signature, hash) {
   var vValue = signature.slice(-2); // last 2 chars
 
   var recoveryNumber = vValue === '1c' ? 1 : 0;
-  var pubKey = uint8ArrayToHex(ecdsaRecover(hexToUnit8Array(sigOnly), recoveryNumber, hexToUnit8Array(removeLeading0x(hash)), false));
+  var point = secp256k1.Signature.fromCompact(hexToUnit8Array(sigOnly)).addRecoveryBit(recoveryNumber).recoverPublicKey(hexToUnit8Array(removeLeading0x(hash)));
+  var pubKey = uint8ArrayToHex(point.toRawBytes(false));
 
   // remove trailing '04'
   pubKey = pubKey.slice(2);

--- a/dist/es/sign.js
+++ b/dist/es/sign.js
@@ -1,9 +1,8 @@
-import { ecdsaSign as secp256k1_sign } from 'secp256k1';
+import { secp256k1 } from 'ethereum-cryptography/secp256k1';
 import { addLeading0x, removeLeading0x } from './util';
 
 /**
  * signs the given message
- * we do not use sign from eth-lib because the pure secp256k1-version is 90% faster
  * @param  {string} privateKey
  * @param  {string} hash
  * @return {string} hexString
@@ -11,8 +10,8 @@ import { addLeading0x, removeLeading0x } from './util';
 export function sign(privateKey, hash) {
   hash = addLeading0x(hash);
   if (hash.length !== 66) throw new Error('EthCrypto.sign(): Can only sign hashes, given: ' + hash);
-  var sigObj = secp256k1_sign(new Uint8Array(Buffer.from(removeLeading0x(hash), 'hex')), new Uint8Array(Buffer.from(removeLeading0x(privateKey), 'hex')));
-  var recoveryId = sigObj.recid === 1 ? '1c' : '1b';
-  var newSignature = '0x' + Buffer.from(sigObj.signature).toString('hex') + recoveryId;
+  var sig = secp256k1.sign(new Uint8Array(Buffer.from(removeLeading0x(hash), 'hex')), new Uint8Array(Buffer.from(removeLeading0x(privateKey), 'hex')));
+  var recoveryId = sig.recovery === 1 ? '1c' : '1b';
+  var newSignature = '0x' + Buffer.from(sig.toCompactRawBytes()).toString('hex') + recoveryId;
   return newSignature;
 }

--- a/dist/lib/public-key.js
+++ b/dist/lib/public-key.js
@@ -6,20 +6,20 @@ Object.defineProperty(exports, "__esModule", {
 exports.compress = compress;
 exports.decompress = decompress;
 exports.toAddress = toAddress;
-var _secp256k = require("secp256k1");
+var _secp256k = require("ethereum-cryptography/secp256k1");
 var _util = require("@ethereumjs/util");
 var _util2 = require("./util");
 function compress(startsWith04) {
   // add trailing 04 if not done before
   var testBuffer = Buffer.from(startsWith04, 'hex');
   if (testBuffer.length === 64) startsWith04 = '04' + startsWith04;
-  return (0, _util2.uint8ArrayToHex)((0, _secp256k.publicKeyConvert)((0, _util2.hexToUnit8Array)(startsWith04), true));
+  return (0, _util2.uint8ArrayToHex)(_secp256k.secp256k1.ProjectivePoint.fromHex((0, _util2.hexToUnit8Array)(startsWith04)).toRawBytes(true));
 }
 function decompress(startsWith02Or03) {
   // if already decompressed an not has trailing 04
   var testBuffer = Buffer.from(startsWith02Or03, 'hex');
   if (testBuffer.length === 64) startsWith02Or03 = '04' + startsWith02Or03;
-  var decompressed = (0, _util2.uint8ArrayToHex)((0, _secp256k.publicKeyConvert)((0, _util2.hexToUnit8Array)(startsWith02Or03), false));
+  var decompressed = (0, _util2.uint8ArrayToHex)(_secp256k.secp256k1.ProjectivePoint.fromHex((0, _util2.hexToUnit8Array)(startsWith02Or03)).toRawBytes(false));
 
   // remove trailing 04
   decompressed = decompressed.substring(2);

--- a/dist/lib/recover-public-key.js
+++ b/dist/lib/recover-public-key.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.recoverPublicKey = recoverPublicKey;
-var _secp256k = require("secp256k1");
+var _secp256k = require("ethereum-cryptography/secp256k1");
 var _util = require("./util");
 /**
  * returns the publicKey for the privateKey with which the messageHash was signed
@@ -20,7 +20,8 @@ function recoverPublicKey(signature, hash) {
   var vValue = signature.slice(-2); // last 2 chars
 
   var recoveryNumber = vValue === '1c' ? 1 : 0;
-  var pubKey = (0, _util.uint8ArrayToHex)((0, _secp256k.ecdsaRecover)((0, _util.hexToUnit8Array)(sigOnly), recoveryNumber, (0, _util.hexToUnit8Array)((0, _util.removeLeading0x)(hash)), false));
+  var point = _secp256k.secp256k1.Signature.fromCompact((0, _util.hexToUnit8Array)(sigOnly)).addRecoveryBit(recoveryNumber).recoverPublicKey((0, _util.hexToUnit8Array)((0, _util.removeLeading0x)(hash)));
+  var pubKey = (0, _util.uint8ArrayToHex)(point.toRawBytes(false));
 
   // remove trailing '04'
   pubKey = pubKey.slice(2);

--- a/dist/lib/sign.js
+++ b/dist/lib/sign.js
@@ -4,11 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.sign = sign;
-var _secp256k = require("secp256k1");
+var _secp256k = require("ethereum-cryptography/secp256k1");
 var _util = require("./util");
 /**
  * signs the given message
- * we do not use sign from eth-lib because the pure secp256k1-version is 90% faster
  * @param  {string} privateKey
  * @param  {string} hash
  * @return {string} hexString
@@ -16,8 +15,8 @@ var _util = require("./util");
 function sign(privateKey, hash) {
   hash = (0, _util.addLeading0x)(hash);
   if (hash.length !== 66) throw new Error('EthCrypto.sign(): Can only sign hashes, given: ' + hash);
-  var sigObj = (0, _secp256k.ecdsaSign)(new Uint8Array(Buffer.from((0, _util.removeLeading0x)(hash), 'hex')), new Uint8Array(Buffer.from((0, _util.removeLeading0x)(privateKey), 'hex')));
-  var recoveryId = sigObj.recid === 1 ? '1c' : '1b';
-  var newSignature = '0x' + Buffer.from(sigObj.signature).toString('hex') + recoveryId;
+  var sig = _secp256k.secp256k1.sign(new Uint8Array(Buffer.from((0, _util.removeLeading0x)(hash), 'hex')), new Uint8Array(Buffer.from((0, _util.removeLeading0x)(privateKey), 'hex')));
+  var recoveryId = sig.recovery === 1 ? '1c' : '1b';
+  var newSignature = '0x' + Buffer.from(sig.toCompactRawBytes()).toString('hex') + recoveryId;
   return newSignature;
 }

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "@types/bn.js": "5.2.0",
     "@noble/hashes": "2.2.0",
     "ethereum-cryptography": "3.2.0",
-    "ethers": "6.16.0",
-    "secp256k1": "5.0.1"
+    "ethers": "6.16.0"
   },
   "overrides": {
     "acorn": "^8"

--- a/src/public-key.js
+++ b/src/public-key.js
@@ -1,6 +1,6 @@
 import {
-    publicKeyConvert
-} from 'secp256k1';
+    secp256k1
+} from 'ethereum-cryptography/secp256k1';
 import {
     pubToAddress,
     toChecksumAddress,
@@ -20,10 +20,9 @@ export function compress(startsWith04) {
     if (testBuffer.length === 64) startsWith04 = '04' + startsWith04;
 
 
-    return uint8ArrayToHex(publicKeyConvert(
-        hexToUnit8Array(startsWith04),
-        true
-    ));
+    return uint8ArrayToHex(
+        secp256k1.ProjectivePoint.fromHex(hexToUnit8Array(startsWith04)).toRawBytes(true)
+    );
 }
 
 export function decompress(startsWith02Or03) {
@@ -32,10 +31,9 @@ export function decompress(startsWith02Or03) {
     const testBuffer = Buffer.from(startsWith02Or03, 'hex');
     if (testBuffer.length === 64) startsWith02Or03 = '04' + startsWith02Or03;
 
-    let decompressed = uint8ArrayToHex(publicKeyConvert(
-        hexToUnit8Array(startsWith02Or03),
-        false
-    ));
+    let decompressed = uint8ArrayToHex(
+        secp256k1.ProjectivePoint.fromHex(hexToUnit8Array(startsWith02Or03)).toRawBytes(false)
+    );
 
     // remove trailing 04
     decompressed = decompressed.substring(2);

--- a/src/recover-public-key.js
+++ b/src/recover-public-key.js
@@ -1,6 +1,6 @@
 import {
-    ecdsaRecover
-} from 'secp256k1';
+    secp256k1
+} from 'ethereum-cryptography/secp256k1';
 import {
     removeLeading0x,
     hexToUnit8Array,
@@ -23,12 +23,12 @@ export function recoverPublicKey(signature, hash) {
 
     const recoveryNumber = vValue === '1c' ? 1 : 0;
 
-    let pubKey = uint8ArrayToHex(ecdsaRecover(
-        hexToUnit8Array(sigOnly),
-        recoveryNumber,
-        hexToUnit8Array(removeLeading0x(hash)),
-        false
-    ));
+    const point = secp256k1.Signature
+        .fromCompact(hexToUnit8Array(sigOnly))
+        .addRecoveryBit(recoveryNumber)
+        .recoverPublicKey(hexToUnit8Array(removeLeading0x(hash)));
+
+    let pubKey = uint8ArrayToHex(point.toRawBytes(false));
 
     // remove trailing '04'
     pubKey = pubKey.slice(2);

--- a/src/sign.js
+++ b/src/sign.js
@@ -1,6 +1,6 @@
 import {
-    ecdsaSign as secp256k1_sign
-} from 'secp256k1';
+    secp256k1
+} from 'ethereum-cryptography/secp256k1';
 import {
     addLeading0x,
     removeLeading0x
@@ -8,7 +8,6 @@ import {
 
 /**
  * signs the given message
- * we do not use sign from eth-lib because the pure secp256k1-version is 90% faster
  * @param  {string} privateKey
  * @param  {string} hash
  * @return {string} hexString
@@ -18,13 +17,13 @@ export function sign(privateKey, hash) {
     if (hash.length !== 66)
         throw new Error('EthCrypto.sign(): Can only sign hashes, given: ' + hash);
 
-    const sigObj = secp256k1_sign(
+    const sig = secp256k1.sign(
         new Uint8Array(Buffer.from(removeLeading0x(hash), 'hex')),
         new Uint8Array(Buffer.from(removeLeading0x(privateKey), 'hex'))
     );
 
-    const recoveryId = sigObj.recid === 1 ? '1c' : '1b';
+    const recoveryId = sig.recovery === 1 ? '1c' : '1b';
 
-    const newSignature = '0x' + Buffer.from(sigObj.signature).toString('hex') + recoveryId;
+    const newSignature = '0x' + Buffer.from(sig.toCompactRawBytes()).toString('hex') + recoveryId;
     return newSignature;
 }


### PR DESCRIPTION
## Summary

- The `secp256k1` npm package (currently a runtime dependency) transitively depends on `elliptic`, which is covered by [GHSA-848j-6mx2-7j84](https://github.com/advisories/GHSA-848j-6mx2-7j84). That advisory applies to every published `elliptic` version up to and including 6.6.1, with **no fixed version available**. Every consumer of `eth-crypto` therefore sees 2 low-severity advisories when they run `npm audit`.
- Migrate `sign`, `publicKey.compress` / `publicKey.decompress`, and `recoverPublicKey` off the `secp256k1` npm package and onto `ethereum-cryptography/secp256k1` (backed by `@noble/curves`). `ethereum-cryptography` is already a runtime dependency and is already used elsewhere in this codebase (`encrypt-with-public-key.js`, `decrypt-with-private-key.js`) for `getSharedSecret` / `getPublicKey`, so this just finishes the migration.
- Drop `secp256k1` from `dependencies`.

After the change, `npm audit --omit=dev` reports **0 vulnerabilities**. Before this change it reported 2 low-severity advisories (both tracing to `elliptic`).

### API surface

No public API changes. `EthCrypto.sign`, `EthCrypto.recover`, `EthCrypto.recoverPublicKey`, `EthCrypto.publicKey.compress`, `EthCrypto.publicKey.decompress`, and `EthCrypto.publicKey.toAddress` all keep the same signatures, inputs, and outputs. Signatures remain RFC6979-deterministic and low-S normalized (verified byte-for-byte against the previous native implementation using TEST_DATA vectors).

### Trade-offs

**Performance regression (Node, local box, 200 iterations via `test/performance.test.js`):**

| op | before (native `secp256k1`) | after (noble via `ethereum-cryptography`) | slowdown |
|----|----:|----:|----:|
| `sign` | ~13 ms / 200 ops (65 μs/op) | ~71 ms / 200 ops (355 μs/op) | ~5.4× |
| `recoverPublicKey` | ~19 ms / 200 ops (95 μs/op) | ~241 ms / 200 ops (1.2 ms/op) | ~12.8× |
| `encryptWithPublicKey` | ~469 ms | ~435 ms | unchanged (already on noble) |
| `decryptWithPrivateKey` | ~396 ms | ~382 ms | unchanged (already on noble) |

Root cause: the old `secp256k1` npm package ships native node-gyp bindings to libsecp256k1 (C). `@noble/curves` is pure JavaScript. For the typical dapp/wallet case (occasional signing, verifying a single message), 355 μs/sig and 1.2 ms/recover are still well below human-perceptible — this is not a user-visible regression. Server workloads doing bulk signature recovery may care; they can always pin a faster library themselves.

**Offsetting wins:**
- **Webpack browser bundle: ~27% smaller** — 532 KB → 389 KB raw (185 KB → 134 KB gzipped). The old browser path pulled in `elliptic` + `crypto-browserify`; the new path reuses `@noble/curves`, which the package already bundled for encrypt/decrypt.
- **No node-gyp in the install path** — faster `npm install`, no C toolchain required, fewer broken installs on unusual platforms (CI, Docker Alpine, etc.).
- **One fewer runtime dep** overall (`secp256k1` removed; nothing added).

### Why this is bigger than a plain version bump

All direct runtime deps are already at latest. The only consumer-facing advisory traces to `elliptic`, which has no released fix on any version. Silencing the alert therefore required removing the dependency chain entirely rather than bumping a version.

## Test plan

- [x] `npm run build` succeeds (es5 + es6 + test + sol)
- [x] `mocha ./test/index.test.js` — all 70 node tests pass (unit, integration, issues, tutorials, performance)
- [x] `mocha ./test/typings.test.js` — all 7 typings tests pass
- [x] `npm run build:webpack` — bundle still compiles; size dropped 27%
- [x] `npm audit --omit=dev` — reports 0 vulnerabilities (was 2 low)
- [x] Byte-for-byte output equivalence verified against the previous native impl for TEST_DATA vectors (`sign`, `recoverPublicKey`, `publicKey.compress`/`decompress`)
- [ ] Browser (`karma`) tests — not run locally; will rely on CI