### PR TITLE
Fix cipher.parse to add leading 04 only if not present

### DIFF
--- a/src/cipher.js
+++ b/src/cipher.js
@@ -35,7 +35,11 @@ export function parse(str) {
     };
 
     // decompress publicKey
-    ret.ephemPublicKey = '04' + decompress(ret.ephemPublicKey);
+    if (ret.ephemPublicKey.startsWith('04')) {
+        ret.ephemPublicKey = '04' + decompress(ret.ephemPublicKey);
+    } else {
+        ret.ephemPublicKey = '04' + decompress(ret.ephemPublicKey);
+    }
 
     return ret;
 }


### PR DESCRIPTION
The `cipher.parse` function unconditionally prepends '04' to the decompressed public key. However, if the stored public key already starts with '04' (uncompressed), this results in an invalid key (e.g., '0404...'). This fix adds a check to only prepend '04' when the decompressed key does not already start with it.